### PR TITLE
chore: hide inappropriate tags

### DIFF
--- a/components/Card/index.js
+++ b/components/Card/index.js
@@ -40,7 +40,6 @@ class Card extends Component {
                 )}
               </div>
             </div>
-
             <div className="content">
               <p className="description">{content.description}</p>
               <div className="control">
@@ -53,11 +52,14 @@ class Card extends Component {
                 <span className="tag is-dark">{content.category}</span>
               </div>
               <div className="tags">
-                {content.tags.map((tag, index) => (
-                  <span key={index} className="tag is-primary">
-                    {tag}
-                  </span>
-                ))}
+                {content.tags.map(
+                  (tag, index) =>
+                    tag.length <= 35 && (
+                      <span key={index} className="tag is-primary">
+                        {tag}
+                      </span>
+                    )
+                )}
               </div>
             </div>
           </div>

--- a/components/Card/index.js
+++ b/components/Card/index.js
@@ -54,7 +54,7 @@ class Card extends Component {
               <div className="tags">
                 {content.tags.map(
                   (tag, index) =>
-                    tag.length <= 35 && (
+                    tag.length <= 20 && (
                       <span key={index} className="tag is-primary">
                         {tag}
                       </span>

--- a/components/Filter/index.js
+++ b/components/Filter/index.js
@@ -69,11 +69,14 @@ class Filter extends Component {
                       onChange={(event) => select(event)}
                     >
                       <option>Todas</option>
-                      {tags.sort().map((item, index) => (
-                        <option value={item} key={`${index}-${item}`}>
-                          {item}
-                        </option>
-                      ))}
+                      {tags.sort().map(
+                        (tag, index) =>
+                          tag.length <= 35 && (
+                            <option value={tag} key={`${index}-${tag}`}>
+                              {tag}
+                            </option>
+                          )
+                      )}
                     </select>
                   </div>
                   <span className="icon is-small is-left">

--- a/components/Filter/index.js
+++ b/components/Filter/index.js
@@ -71,7 +71,7 @@ class Filter extends Component {
                       <option>Todas</option>
                       {tags.sort().map(
                         (tag, index) =>
-                          tag.length <= 35 && (
+                          tag.length <= 20 && (
                             <option value={tag} key={`${index}-${tag}`}>
                               {tag}
                             </option>


### PR DESCRIPTION
Na daily de ontem comentei sobre essa questão de tags muito grandes, com frases. O que no fim não é uma tag.
Fiz um correção para tags com mais de 35 caracteres. 
Tanto `uma tag bem grande mesmo de verdade` quanto `abcdefghijklmnopqrstuvwxyz123456789` tem 35 caracteres e esse vai ser o limite para o tamanho da tag. 
Também falei com a Thaíssa para colocarmos uma mensagem no formulário falando o que é a tag para evitar coisas que não são tags de verdade.