### PR TITLE
fix: members type

### DIFF
--- a/components/CommunityForm/index.js
+++ b/components/CommunityForm/index.js
@@ -35,7 +35,8 @@ const CommunityForm = ({ service, initialValues, loading, credentials }) => {
       initialValues={initialValues}
       validationSchema={SignupSchema}
       onSubmit={(values) => {
-        values.members = parseInt(values.members.replace('.', ''));
+        if (typeof values.members === 'string')
+          values.members = parseInt(values.members.replace('.', ''));
         service(values);
       }}
     >


### PR DESCRIPTION
Temos uma lib que coloca pontos decimais no campo `membro` e consequentemente transforma o numero em string, tratamos isso antes de cadastrar a comunidade.
 
Quando uma comunidade é editada sem alterar o campo `membros`, esse campo é enviado como `number`, quebrando a função `replace`.

Portanto foi criada a condicional abaixo.

Fluxo foi testado manualmente criando comunidade, editando um campo aleatório e editando os membros.