### PR TITLE
docs: :memo: remove `EXPOSE 3000` from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,4 @@ RUN npm ci
 
 COPY . .
 
-EXPOSE 3000
-
 CMD ["npm", "start"]


### PR DESCRIPTION
Ports are being exposed and redirected at docker-compose.yaml